### PR TITLE
Upgrade to Elixir 1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ TheFuzz
 
 **Fuzzy string matching algorithm implementations**
 
-TheFuzz is a collection of metrics and phonetic (fuzzy string matching) algorithms for Elixir.  It is based entirely on the [rockymadden stringmetric library](https://github.com/rockymadden/stringmetric) written by Rocky Madden for Scala.  There will eventually be Elixir implementations of all of the string metric and phonetic algorithms implemented in his library.  The library provides facilities to perform approximate string matching, measurement of string similarity/distance, indexing by word pronunciation, and sounds-like comparisons. The best way to see usage is to check out the tests and the [documentation](http://smashedtoatoms.github.io/the_fuzz).
+TheFuzz is a collection of metrics and phonetic (fuzzy string matching) algorithms for Elixir.  It is based entirely on the [rockymadden stringmetric library](https://github.com/rockymadden/stringmetric) written by Rocky Madden for Scala.  There will eventually be Elixir implementations of all of the string metric and phonetic algorithms implemented in his library.  The library provides facilities to perform approximate string matching, measurement of string similarity/distance, indexing by word pronunciation, and sounds-like comparisons. The best way to see usage is to check out the tests and the [documentation](http://smashedtoatoms.github.io/the_fuzz/api-reference.html).
 
 The following algorithms are currently implemented.
 

--- a/lib/the_fuzz/phonetic/metaphone_algorithm.ex
+++ b/lib/the_fuzz/phonetic/metaphone_algorithm.ex
@@ -4,8 +4,7 @@ defmodule TheFuzz.Phonetic.MetaphoneAlgorithm do
   Metaphone) of a string.
   """
 
-  import String, only: [downcase: 1, first: 1, split_at: 2, last: 1, at: 2,
-    codepoints: 1]
+  import String, only: [downcase: 1, first: 1, split_at: 2, last: 1, at: 2]
   import TheFuzz.Util, only: [len: 1, is_alphabetic?: 1, deduplicate: 1]
 
   @doc """

--- a/lib/the_fuzz/phonetic/metaphone_metric.ex
+++ b/lib/the_fuzz/phonetic/metaphone_metric.ex
@@ -6,7 +6,7 @@ defmodule TheFuzz.Phonetic.MetaphoneMetric do
 
   import TheFuzz.Phonetic.MetaphoneAlgorithm, only: [compute: 1]
   import TheFuzz.Util, only: [len: 1, is_alphabetic?: 1]
-  import String, only: [first: 1, codepoints: 1]
+  import String, only: [first: 1]
 
   @doc """
     Compares two values phonetically and returns a boolean of whether they match

--- a/lib/the_fuzz/similarity/levenshtein.ex
+++ b/lib/the_fuzz/similarity/levenshtein.ex
@@ -22,22 +22,22 @@ defmodule TheFuzz.Similarity.Levenshtein do
   def compare(a, b) when byte_size(a) == 0 or byte_size(b) == 0, do: nil
   def compare(a, b) when a == b, do: 0
   def compare(a, b) do
-    distance(a |> String.to_char_list, b |> String.to_char_list)
+    distance(a |> String.to_charlist, b |> String.to_charlist)
   end
 
   defp store_result(key, result, cache) do
-    {result, Dict.put(cache, key, result)}
+    {result, Map.put(cache, key, result)}
   end
 
-  defp distance(a, b), do: distance(a, b, HashDict.new) |> elem(0)
+  defp distance(a, b), do: distance(a, b, Map.new) |> elem(0)
   defp distance(a, [] = b, cache), do: store_result({a, b}, length(a), cache)
   defp distance([] = a, b, cache), do: store_result({a, b}, length(b), cache)
   defp distance([x | rest1], [x | rest2], cache) do
     distance(rest1, rest2, cache)
   end
   defp distance([_ | rest1] = a, [_ | rest2] = b, cache) do
-    case Dict.has_key?(cache, {a, b}) do
-      true -> {Dict.get(cache, {a, b}), cache}
+    case Map.has_key?(cache, {a, b}) do
+      true -> {Map.get(cache, {a, b}), cache}
       false ->
         {l1, c1} = distance(a, rest2, cache)
         {l2, c2} = distance(rest1, b, c1)

--- a/lib/the_fuzz/similarity/weighted_levenshtein.ex
+++ b/lib/the_fuzz/similarity/weighted_levenshtein.ex
@@ -44,15 +44,15 @@ defmodule TheFuzz.Similarity.WeightedLevenshtein do
   def compare(a, b, _) when byte_size(a) == 0 or byte_size(b) == 0, do: nil
   def compare(a, b, _) when a == b, do: 0
   def compare(a, b, %{} = weights) do
-    distance(a |> String.to_char_list, b |> String.to_char_list, weights)
+    distance(a |> String.to_charlist, b |> String.to_charlist, weights)
   end
 
   defp store_result(key, result, cache) do
-    {result, Dict.put(cache, key, result)}
+    {result, Map.put(cache, key, result)}
   end
 
   defp distance(a, b, weights) do
-    distance(a, b, weights, HashDict.new) |> elem(0)
+    distance(a, b, weights, Map.new) |> elem(0)
   end
   defp distance(a, [] = b, %{delete: delete_cost}, cache) do
     store_result({a, b}, delete_cost * length(a), cache)
@@ -68,8 +68,8 @@ defmodule TheFuzz.Similarity.WeightedLevenshtein do
     insert: insert_cost,
     replace: replace_cost
   } = weights, cache) do
-    case Dict.has_key?(cache, {a, b}) do
-      true -> {Dict.get(cache, {a, b}), cache}
+    case Map.has_key?(cache, {a, b}) do
+      true -> {Map.get(cache, {a, b}), cache}
       false ->
         {l1, c1} = distance(a, rest2, weights, cache)
         {l2, c2} = distance(rest1, b, weights, c1)

--- a/lib/the_fuzz/string_metric.ex
+++ b/lib/the_fuzz/string_metric.ex
@@ -3,7 +3,5 @@ defmodule TheFuzz.StringMetric do
   Specifies the string metric api which an module needs to implement to provide 
   string comparison methods
   """
-  use Behaviour
-
-  defcallback compare(String.t, String.t) :: any
+  @callback compare(String.t, String.t) :: any
 end

--- a/mix.exs
+++ b/mix.exs
@@ -3,21 +3,21 @@ defmodule TheFuzz.Mixfile do
 
   def project do
     [app: :the_fuzz,
-     version: "0.3.0",
-     elixir: "~> 1.2.1",
+     version: "0.4.0",
+     elixir: "~> 1.6",
      name: "TheFuzz",
      source_url: "https://github.com/smashedtoatoms/the_fuzz",
      homepage_url: "https://github.com/smashedtoatoms/the_fuzz",
-     description: description,
-     package: package,
-     deps: deps]
+     description: description(),
+     package: package(),
+     deps: deps()]
   end
 
   # Configuration for the OTP application
   #
   # Type `mix help compile.app` for more information
   def application do
-    [applications: [:logger]]
+    [extra_applications: [:logger]]
   end
 
   # Dependencies can be hex.pm packages:
@@ -31,9 +31,9 @@ defmodule TheFuzz.Mixfile do
   # Type `mix help deps` for more examples and options
   defp deps do
     [
-      {:earmark, "~> 0.1", only: :dev},
-      {:ex_doc, "~> 0.11", only: :dev},
-      {:dogma, "~> 0.0", only: :dev}
+      {:earmark, "~> 1.2", only: :dev},
+      {:ex_doc, "~> 0.18", only: :dev},
+      {:dogma, "~> 0.1", only: :dev}
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,6 @@
-%{"dogma": {:hex, :dogma, "0.0.3"},
-  "earmark": {:hex, :earmark, "0.2.1"},
-  "ex_doc": {:hex, :ex_doc, "0.11.5"}}
+%{
+  "dogma": {:hex, :dogma, "0.1.16", "3c1532e2f63ece4813fe900a16704b8e33264da35fdb0d8a1d05090a3022eef9", [:mix], [{:poison, ">= 2.0.0", [hex: :poison, repo: "hexpm", optional: false]}], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.4", "99b637c62a4d65a20a9fb674b8cffb8baa771c04605a80c911c4418c69b75439", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm"},
+}

--- a/test/similarity/n_gram_test.exs
+++ b/test/similarity/n_gram_test.exs
@@ -1,7 +1,7 @@
 defmodule NGramTest do
   use ExUnit.Case
 
-  import TheFuzz.Similarity.NGram, only: [compare: 2, compare: 3]
+  import TheFuzz.Similarity.NGram, only: [compare: 3]
 
   test "return None with empty arguments" do
     assert compare("", "", 1) == nil

--- a/test/similarity/weighted_levenshtein_test.exs
+++ b/test/similarity/weighted_levenshtein_test.exs
@@ -1,7 +1,7 @@
 defmodule WeightedLevenshteinTest do
   use ExUnit.Case
 
-  import TheFuzz.Similarity.WeightedLevenshtein, only: [compare: 2, compare: 3]
+  import TheFuzz.Similarity.WeightedLevenshtein, only: [compare: 3]
 
   test "returns nil with empty arguments" do
     assert compare("", "", %{delete: 10, insert: 0.1, replace: 1}) == nil


### PR DESCRIPTION
Here's a quick PR to upgrade TheFuzz to more current Elixir standards (mostly).

* Upgrades elixir version to 1.6 in mix.exs
* Assumes a version bump from 0.3.0 would be a good idea due to the large version gap created
  * @smashedtoatoms I've thrown in a bump to 0.4.0, but that's just an idea
* Moves `:logger` to `extra_applications`
* Upgrades all `:dev` dependencies to latest
* Swaps deprecated `HashDict` and `Dict` usages for `Map`
* Removes most compiler warnings
* Minor documentation update (rolled-up from #6)
* Ensures tests still pass

**This PR does not:**
Address Elixir 1.5 warnings (e.g. `fun` vs. `fun()` other than those in `mix.exs`)
Reformat any code via 1.6's `mix format`